### PR TITLE
Fix usage strings for HTML mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from aiogram import Bot, Dispatcher
+from aiogram.enums import ParseMode
 import config
 from database.db import init_db
 from handlers import user_handlers, admin_handlers
@@ -13,9 +14,8 @@ logger = logging.getLogger(__name__)
 # Создаём таблицы в БД (если ещё не созданы)
 init_db()
 
-# Инициализируем бота (УБРАЛИ parse_mode из конструктора)
-# Будет использовать MarkdownV2 (по умолчанию) или простой текст.
-bot = Bot(token=config.TOKEN)
+# Инициализируем бота с режимом форматирования HTML
+bot = Bot(token=config.TOKEN, parse_mode=ParseMode.HTML)
 
 # Dispatcher
 dp = Dispatcher()

--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -24,7 +24,7 @@ async def cmd_add_product(message: Message) -> None:
     if len(parts) != 5:
         await message.reply(
             "Использование:\n"
-            "/add_product <name>|<description>|<price>|<quantity>|<category_id>"
+            "/add_product &lt;name&gt;|&lt;description&gt;|&lt;price&gt;|&lt;quantity&gt;|&lt;category_id&gt;"
         )
         return
     name, description, price_str, qty_str, cat_id_str = [p.strip() for p in parts]
@@ -55,7 +55,7 @@ async def cmd_update_product(message: Message) -> None:
     if len(parts) != 6 or not parts[0].isdigit():
         await message.reply(
             "Использование:\n"
-            "/update_product <product_id>|<name?>|<description?>|<price?>|<quantity?>|<category_id?>"
+            "/update_product &lt;product_id&gt;|&lt;name?&gt;|&lt;description?&gt;|&lt;price?&gt;|&lt;quantity?&gt;|&lt;category_id?&gt;"
         )
         return
     product_id = int(parts[0])
@@ -85,7 +85,7 @@ async def cmd_delete_product(message: Message) -> None:
         return
     parts = message.text.split()
     if len(parts) != 2 or not parts[1].isdigit():
-        await message.reply("Использование: /delete_product <product_id>")
+        await message.reply("Использование: /delete_product &lt;product_id&gt;")
         return
     product_id = int(parts[1])
     with next(get_db()) as db:

--- a/handlers/user_handlers.py
+++ b/handlers/user_handlers.py
@@ -19,9 +19,9 @@ async def cmd_start(message: Message) -> None:
         "Доступные команды:\n"
         "/categories — список категорий\n"
         "/products [category_id] — товары\n"
-        "/buy <product_id> <quantity> — купить товар\n"
+        "/buy &lt;product_id&gt; &lt;quantity&gt; — купить товар\n"
         "/orders — ваши заказы\n"
-        "/order <order_id> — детали заказа\n"
+        "/order &lt;order_id&gt; — детали заказа\n"
         "/help — эта подсказка\n"
     )
 
@@ -36,7 +36,7 @@ async def cmd_categories(message: Message) -> None:
     text = "<b>Категории:</b>\n"
     for cat in cats:
         text += f"{cat.id}. {cat.name}\n"
-    text += "\nЧтобы увидеть товары, введите /products <category_id>"
+    text += "\nЧтобы увидеть товары, введите /products &lt;category_id&gt;"
     await message.reply(text)
 
 
@@ -57,7 +57,7 @@ async def cmd_products(message: Message) -> None:
             f"{p.id}. {p.name} — {p.price:.2f}₽ (в наличии: {p.quantity})\n"
             f"   Категория: {p.category.name}\n"
         )
-    text += "\nЧтобы купить: /buy <product_id> <quantity>"
+    text += "\nЧтобы купить: /buy &lt;product_id&gt; &lt;quantity&gt;"
     await message.reply(text)
 
 
@@ -65,7 +65,7 @@ async def cmd_products(message: Message) -> None:
 async def cmd_buy(message: Message) -> None:
     parts = message.text.split()
     if len(parts) != 3 or not parts[1].isdigit() or not parts[2].isdigit():
-        await message.reply("Использование: /buy <product_id> <quantity>")
+        await message.reply("Использование: /buy &lt;product_id&gt; &lt;quantity&gt;")
         return
     product_id = int(parts[1])
     qty = int(parts[2])
@@ -107,7 +107,7 @@ async def cmd_orders(message: Message) -> None:
     for o in orders:
         ts = o.created_at.strftime("%Y-%m-%d %H:%M")
         text += f"#{o.id}: <i>{o.status}</i>, {ts}\n"
-    text += "\nПодробнее: /order <order_id>"
+    text += "\nПодробнее: /order &lt;order_id&gt;"
     await message.reply(text)
 
 
@@ -115,7 +115,7 @@ async def cmd_orders(message: Message) -> None:
 async def cmd_order_details(message: Message) -> None:
     parts = message.text.split()
     if len(parts) != 2 or not parts[1].isdigit():
-        await message.reply("Использование: /order <order_id>")
+        await message.reply("Использование: /order &lt;order_id&gt;")
         return
     order_id = int(parts[1])
     tg_id = message.from_user.id


### PR DESCRIPTION
## Summary
- escape angle brackets in user and admin commands
- enable bot HTML formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684211799274832c8987c19639f305f2